### PR TITLE
add the ability to compare 2 uuids from the scripts itself

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -1,0 +1,103 @@
+# Network Scripts
+
+The purpose of the network scripts is to run uperf workload on the Openshift Cluster.
+There are 4 types network tests:
+1. pod to pod using Hostnetwork
+2. pod to pod using SDN
+3. pod to pod using Service
+4. pod to pod using Multus (NetworkAttachmentDefinition needs to be provided)
+
+Running from CLI:
+
+```sh
+$ ./run_<test-name>_network_test_fromgit.sh 
+```
+
+## Environment variables
+
+### ES_SERVER
+Default: `search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com`  
+Public elasticsearch server
+
+### ES_PORT
+Default: `80`  
+Port number for public elasticsearch server
+
+### METADATA_COLLECTION
+Default: `true`   
+Enable/Disable collection of metadata
+
+### COMPARE
+Default: `false`   
+Enable/Disable the ability to compare two uperf runs. If set to `true`, the next set of environment variables pertaining to the type of test are required
+
+### ES_SERVER_BASELINE 
+Default: `search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com`   
+Elasticsearch server used used by the baseline run 
+
+### ES_PORT_BASELINE
+Default: `80`  
+Port number for the elasticsearch server used by the baseline run
+
+### BASELINE_HOSTNET_UUID
+Default: ``   
+Baseline UUID for hostnetwork test  
+
+### BASELINE_POD_1P_UUID
+Default: ``   
+Baseline UUID for pod to pod using SDN test with 1 uperf client-server pair
+
+### BASELINE_POD_2P_UUID
+Default: ``   
+Baseline UUID for pod to pod using SDN test with 2 uperf client-server pair
+
+### BASELINE_POD_4P_UUID
+Default: ``   
+Baseline UUID for pod to pod using SDN test with 4 uperf client-server pair
+
+### BASELINE_SVC_1P_UUID
+Default: ``   
+Baseline UUID for pod to pod using service test with 1 uperf client-server pair
+
+### BASELINE_SVC_2P_UUID
+Default: ``   
+Baseline UUID for pod to pod using service test with 2 uperf client-server pair
+
+### BASELINE_SVC_4P_UUID
+Default: ``   
+Baseline UUID for pod to pod using service test with 4 uperf client-server pair
+
+### BASELINE_MULTUS_UUID
+Default: ``   
+Baseline UUID for multus test
+
+### THROUGHPUT_TOLERANCE
+Default: `5`   
+Accepeted deviation in percentage for throughput when compared to a baseline run
+
+### LATENCY_TOLERANCE
+Default: `5`   
+Accepeted deviation in percentage for latency when compared to a baseline run
+
+
+## Suggested configurations
+
+```sh
+export ES_SERVER=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
+export ES_PORT=80
+export METADATA_COLLECTION=true
+export COMPARE=true
+export ES_SERVER_BASELINE=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
+export ES_PORT_BASELINE=80
+export BASELINE_HOSTNET_UUID=
+export BASELINE_POD_1P_UUID=
+export BASELINE_POD_2P_UUID=
+export BASELINE_POD_4P_UUID=
+export BASELINE_SVC_1P_UUID=
+export BASELINE_SVC_2P_UUID=
+export BASELINE_SVC_4P_UUID=
+export BASELINE_MULTUS_UUID=
+export THROUGHPUT_TOLERANCE=5
+export LATENCY_TOLERANCE=5
+```
+

--- a/workloads/network-perf/compare.py
+++ b/workloads/network-perf/compare.py
@@ -49,7 +49,7 @@ def percent_change(value, reference):
     else:
         return -1
 
-def compare(data, tolerance=5, latency=False):
+def compare(data, tolerance, latency=False):
     ref_val = data[params.uuid[0]]
     current_tuple = [(k,v) for k,v in data.items() if k!=params.uuid[0]][0]
     percent_diff = percent_change(current_tuple[1], ref_val)
@@ -87,7 +87,7 @@ if test_type in data['test_type.keyword'] :
                 if test_type == "rr" :
                     comparison = compare(result[main_metric[test_type]], int(params.tolerance[0]), latency=True)
                 else:
-                    comparison = compare(result[main_metric[test_type]], tolerance=int(params.tolerance[0]))
+                    comparison = compare(result[main_metric[test_type]], int(params.tolerance[0]))
                 if params.uuid[0] not in comparison :
                     print("TEST FAILURE: Uperf reports regrerssion which is beyond the acceptable deviation of {}%".format(params.tolerance[0]))
                     print("Test: {}    Protocol: {}    Message_size: {}    Threads: {}".format(

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -4,6 +4,7 @@ set -x
 _es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
 _es_port=80
 _metadata_collection=true
+_baseline_hostnet_uuid=
 
 if [[ ${ES_SERVER} ]]; then
   _es=${ES_SERVER}
@@ -15,6 +16,10 @@ fi
 
 if [[ ${METADATA_COLLECTION} ]]; then
   _metadata_collection=${METADATA_COLLECTION}
+fi
+
+if [[ ${BASELINE_HOSTNET_UUID} ]]; then
+  _baseline_hostnet_uuid=${BASELINE_HOSTNET_UUID}
 fi
 
 kubeconfig=$2
@@ -110,6 +115,13 @@ done
 if [ "$uperf_state" == "1" ] ; then
   echo "Workload failed"
   exit 1
+fi
+
+if [[ ${COMPARE} == "true" ]] ; then
+  baseline_uperf_uuid=${_baseline_hostnet_uuid}
+  compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -o json | jq -r .items[].status.uuid)  
+  echo "Comparing current test uuid ${compare_uperf_uuid} with baseline uuid ${baseline_uperf_uuid}"
+  ./run_network_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid}
 fi
 
 oc -n my-ripsaw delete benchmark/uperf-benchmark

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -4,6 +4,7 @@ set -x
 _es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
 _es_port=80
 _metadata_collection=true
+_baseline_multus_uuid=
 
 if [[ ${ES_SERVER} ]]; then
   _es=${ES_SERVER}
@@ -15,6 +16,10 @@ fi
 
 if [[ ${METADATA_COLLECTION} ]]; then
   _metadata_collection=${METADATA_COLLECTION}
+fi
+
+if [[ ${BASELINE_MULTUS_UUID} ]]; then
+  _baseline_multus_uuid=${BASELINE_MULTUS_UUID}
 fi
 
 kubeconfig=$2
@@ -133,6 +138,13 @@ done
 if [ "$uperf_state" == "1" ] ; then
   echo "Workload failed"
   exit 1
+fi
+
+if [[ ${COMPARE} == "true" ]] ; then
+  baseline_uperf_uuid=${_baseline_multus_uuid}
+  compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -o json | jq -r .items[].status.uuid)
+  echo "Comparing current test uuid ${compare_uperf_uuid} with baseline uuid ${baseline_uperf_uuid}"
+  ./run_network_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid}
 fi
 
 oc -n my-ripsaw delete benchmark/uperf-benchmark

--- a/workloads/network-perf/run_network_compare.sh
+++ b/workloads/network-perf/run_network_compare.sh
@@ -2,45 +2,65 @@
 datasource="elasticsearch"
 tool="uperf"
 function="compare"
+throughput_tolerance=5
+latency_tolerance=5
+
 if [ "$#" -ne 2 ]; then
   echo "Syntax error : Script expects two UUIDs"
   echo "               ./run_network_compare.sh <baseline_uuid> <new_uuid>"
   exit 1
 fi
+
 base_uuid=$1
 compare_uuid=$2
-es=${ES_SERVER}
-if [ "$es" == "" ]; then
-  echo "Unable to execute compare - no ES passed"
+es_server=${ES_SERVER}
+es_port=${ES_PORT}
+es_server_baseline=${ES_SERVER}
+es_port_baseline=${ES_PORT}
+
+if [ "$es_server" == "" ] || [ "$es_port" == "" ]; then
+  echo "Unable to execute compare - no elasticsearch server and/or port passed"
   exit 1
+fi
+
+if [[ ${ES_SERVER_BASELINE} ]] && [[ ${ES_PORT_BASELINE} ]]; then
+  es_server_baseline=${ES_SERVER_BASELINE}
+  es_port_baseline=${ES_PORT_BASELINE}
+fi
+
+if [[ ${THROUGHPUT_TOLERANCE} ]]; then
+  throughput_tolerance=${THROUGHPUT_TOLERANCE}
+fi
+
+if [[ ${LATENCY_TOLERANCE} ]]; then
+  latency_tolerance=${LATENCY_TOLERANCE}
 fi
 
 git clone https://github.com/cloud-bulldozer/touchstone
 cd touchstone
-python -m venv ./compare
+python3 -m venv ./compare
 source ./compare/bin/activate
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 python3 setup.py develop
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to install touchstone"
   exit 1
 fi
 
-touchstone_compare $tool $datasource ripsaw -url $es -u $base_uuid $compare_uuid -o yaml | tee ../compare.yaml
+touchstone_compare $tool $datasource ripsaw -url $es_server_baseline:$es_port_baseline $es_server:$es_port -u $base_uuid $compare_uuid -o yaml | tee ../compare.yaml
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to run touchstone"
   exit 1
 fi
-
-failed=0
 cd ../
+failed=0
 echo "Checking Stream TCP"
-python compare.py --result compare.yaml --uuid $base_uuid --test stream --protocol tcp || failed=1
+python3 compare.py --result compare.yaml --uuid $base_uuid --test stream --protocol tcp --tolerance $throughput_tolerance || failed=1
 echo "Checking Stream UDP"
-python compare.py --result compare.yaml --uuid $base_uuid --test stream --protocol udp || failed=1
+python3 compare.py --result compare.yaml --uuid $base_uuid --test stream --protocol udp --tolerance $throughput_tolerance || failed=1
 echo "Checking RR TCP"
-python compare.py --result compare.yaml --uuid $base_uuid --test rr --protocol tcp || failed=1
+python3 compare.py --result compare.yaml --uuid $base_uuid --test rr --protocol tcp --tolerance $latency_tolerance || failed=1
 echo "Checking RR UDP"
-python compare.py --result compare.yaml --uuid $base_uuid --test rr --protocol tcp || failed=1
+python3 compare.py --result compare.yaml --uuid $base_uuid --test rr --protocol tcp --tolerance $latency_tolerance || failed=1
 echo "Compare complete"
 exit $failed

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -4,6 +4,9 @@ set -x
 _es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
 _es_port=80
 _metadata_collection=true
+_baseline_svc_1p_uuid=
+_baseline_svc_2p_uuid=
+_baseline_svc_4p_uuid=
 
 if [[ ${ES_SERVER} ]]; then
   _es=${ES_SERVER}
@@ -11,6 +14,18 @@ fi
 
 if [[ ${ES_PORT} ]]; then
   _es_port=${ES_PORT}
+fi
+
+if [[ ${BASELINE_SVC_1P_UUID} ]]; then
+  _baseline_svc_1p_uuid=${BASELINE_SVC_1P_UUID}
+fi
+
+if [[ ${BASELINE_SVC_2P_UUID} ]]; then
+  _baseline_svc_2p_uuid=${BASELINE_SVC_2P_UUID}
+fi
+
+if [[ ${BASELINE_SVC_4P_UUID} ]]; then
+  _baseline_svc_4p_uuid=${BASELINE_SVC_4P_UUID}
 fi
 
 if [[ ${METADATA_COLLECTION} ]]; then
@@ -112,6 +127,19 @@ done
 if [ "$uperf_state" == "1" ] ; then
   echo "Workload failed"
   exit 1
+fi
+
+if [[ ${COMPARE} == "true" ]] ; then
+  if [ "${pairs}" == "1" ] ; then
+    baseline_uperf_uuid=${_baseline_svc_1p_uuid}
+  elif [ "${pairs}" == "2" ] ; then
+    baseline_uperf_uuid=${_baseline_svc_2p_uuid}
+  elif [ "${pairs}" == "4" ] ; then
+    baseline_uperf_uuid=${_baseline_svc_4p_uuid}
+  fi
+  compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -o json | jq -r .items[].status.uuid)
+  echo "Comparing current test uuid ${compare_uperf_uuid} with baseline uuid ${baseline_uperf_uuid}"
+  ./run_network_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid}
 fi
 
 oc -n my-ripsaw delete benchmark/uperf-benchmark


### PR DESCRIPTION
@jtaleric @chaitanyaenr
This commit gives us the ability to compare the test_uuid with the baseline_uuid if we set COMPARE=true. Also this commit adds a tuning to specify throughput and latency tolerances individually (default=5). This is because latency can vary a lot depending on the environment (ex. 4.3 perfscale tests). 
The baseline_uuid vars for different tests will be set once they are finalised  