### PR TITLE
remove 8 threads from the test to reduce CI runtime

### DIFF
--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -86,7 +86,6 @@ spec:
       pair: 1
       nthrs:
         - 1
-        - 8
       protos:
         - tcp
         - udp

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -98,7 +98,6 @@ spec:
       pair: ${pairs}
       nthrs:
         - 1
-        - 8
       protos:
         - tcp
         - udp

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -98,7 +98,6 @@ spec:
       pair: ${pairs}
       nthrs:
         - 1
-        - 8
       protos:
         - tcp
         - udp


### PR DESCRIPTION
..also we do not report 8 threads numbers in perfscale reports. The multus script will continue to have  1 and 8 threads as we are currently testing on baremetal-ci
@chaitanyaenr @jtaleric 