### PR TITLE
set KUBECONFIG only when passed as argument

### DIFF
--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -15,11 +15,9 @@ if [[ "${ES_PORT}" ]]; then
   _es_port=${ES_PORT}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -22,11 +22,9 @@ if [[ ${BASELINE_HOSTNET_UUID} ]]; then
   _baseline_hostnet_uuid=${BASELINE_HOSTNET_UUID}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -22,11 +22,9 @@ if [[ ${BASELINE_MULTUS_UUID} ]]; then
   _baseline_multus_uuid=${BASELINE_MULTUS_UUID}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -32,11 +32,9 @@ if [[ ${METADATA_COLLECTION} ]]; then
   _metadata_collection=${METADATA_COLLECTION}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -32,11 +32,9 @@ if [[ ${METADATA_COLLECTION} ]]; then
   _metadata_collection=${METADATA_COLLECTION}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then

--- a/workloads/storage-perf/run_storage_tests_fromgit.sh
+++ b/workloads/storage-perf/run_storage_tests_fromgit.sh
@@ -12,11 +12,9 @@ if [[ "${ES_PORT}" ]]; then
   _es_port=${ES_PORT}
 fi
 
-kubeconfig=$2
-if [ "$kubeconfig" == "" ]; then
-  kubeconfig="$HOME/.kube/config"
+if [ ! -z ${2} ]; then
+  export KUBECONFIG=${2}
 fi
-export KUBECONFIG=$kubeconfig
 
 cloud_name=$1
 if [ "$cloud_name" == "" ]; then


### PR DESCRIPTION
Latest change seems that broke openshift upstream CI (https://prow.svc.ci.openshift.org/?job=*etcd-azure-perf-test-daily*) as the kubeconfig file is not in the home directory
By default kubectl and oc clients already look for kube config file at $HOME/.kube/config so it's not required to set it.