### PR TITLE
Updating metadata collection definition PR 315 of ripsaw

### DIFF
--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -50,9 +50,10 @@ spec:
     port: $_es_port
   clustername: $cloud_name
   test_user: ${cloud_name}-ci
-  metadata_collection: true
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: true
+    sa: backpack-view
+    privileged: true
   workload:
     name: byowl
     args:

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -23,9 +23,10 @@ spec:
     port: $_es_port
   clustername: $cloud_name
   test_user: ${cloud_name}-hostnetwork-ci
-  metadata_collection: ${_metadata_collection}
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: ${_metadata_collection}
+    sa: backpack-view
+    privileged: true
   workload:
     name: uperf
     args:

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -44,9 +44,10 @@ spec:
     port: $_es_port
   clustername: $cloud_name
   test_user: ${cloud_name}-multus-ci-${_pair}p
-  metadata_collection: ${_metadata_collection}
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: ${_metadata_collection}
+    sa: backpack-view
+    privileged: true
   workload:
     name: uperf
     args:

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -37,9 +37,10 @@ spec:
     port: $_es_port
   clustername: $cloud_name
   test_user: ${cloud_name}-default-ci-${pairs}p
-  metadata_collection: ${_metadata_collection}
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: ${_metadata_collection}
+    sa: backpack-view
+    privileged: true
   workload:
     name: uperf
     args:

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -36,9 +36,10 @@ spec:
     port: $_es_port
   clustername: $cloud_name
   test_user: ${cloud_name}-serviceip-ci-${pairs}p
-  metadata_collection: ${_metadata_collection}
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: ${_metadata_collection}
+    sa: backpack-view
+    privileged: true
   workload:
     name: uperf
     args:

--- a/workloads/storage-perf/run_storage_tests_fromgit.sh
+++ b/workloads/storage-perf/run_storage_tests_fromgit.sh
@@ -44,9 +44,10 @@ metadata:
   name: fio-benchmark
   namespace: my-ripsaw
 spec:
-  metadata_collection: true
-  metadata_sa: backpack-view
-  metadata_privileged: true
+  metadata:
+    collection: true
+    sa: backpack-view
+    privileged: true
   elasticsearch:
     server: $_es
     port: $_es_port


### PR DESCRIPTION
This update brings in the metadata definition changes from PR https://github.com/cloud-bulldozer/ripsaw/pull/315 of ripsaw. As such, it needs to be merged after it as well.

Closes #31 