### PR TITLE
Fixing metadata variable from sa to serviceaccount

### DIFF
--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -25,7 +25,7 @@ spec:
   test_user: ${cloud_name}-hostnetwork-ci
   metadata:
     collection: ${_metadata_collection}
-    sa: backpack-view
+    serviceaccount: backpack-view
     privileged: true
   workload:
     name: uperf

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -46,7 +46,7 @@ spec:
   test_user: ${cloud_name}-multus-ci-${_pair}p
   metadata:
     collection: ${_metadata_collection}
-    sa: backpack-view
+    serviceaccount: backpack-view
     privileged: true
   workload:
     name: uperf

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -39,7 +39,7 @@ spec:
   test_user: ${cloud_name}-default-ci-${pairs}p
   metadata:
     collection: ${_metadata_collection}
-    sa: backpack-view
+    serviceaccount: backpack-view
     privileged: true
   workload:
     name: uperf

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -38,7 +38,7 @@ spec:
   test_user: ${cloud_name}-serviceip-ci-${pairs}p
   metadata:
     collection: ${_metadata_collection}
-    sa: backpack-view
+    serviceaccount: backpack-view
     privileged: true
   workload:
     name: uperf


### PR DESCRIPTION
The service account variable was changed from sa to serviceaccount. This fixes it here.