### PR TITLE
Add Cerberus check while running Uperf

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -99,6 +99,10 @@ Accepeted deviation in percentage for throughput when compared to a baseline run
 Default: `5`   
 Accepeted deviation in percentage for latency when compared to a baseline run
 
+### CERBERUS_URL
+Default: ``     
+URL to check the health of the cluster using Cerberus (https://github.com/openshift-scale/cerberus).
+
 ### EMAIL_ID_FOR_RESULTS_SHEET
 Default: *Commented out*       
 For this you will have to place Google Service Account Key in /plow/workloads/network-perf dir.   
@@ -128,6 +132,7 @@ export BASELINE_SVC_4P_UUID=
 export BASELINE_MULTUS_UUID=
 export THROUGHPUT_TOLERANCE=5
 export LATENCY_TOLERANCE=5
+export CERBERUS_URL=http://1.2.3.4:8080
 #export EMAIL_ID_FOR_RESULTS_SHEET=<your_email_id>  # Will only work if you have google service account key
 ```
 

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -x
 
+# Check cluster's health
+if [[ ${CERBERUS_URL} ]]; then
+  response=$(curl ${CERBERUS_URL})
+  if [ "$response" != "True" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
+fi
+
 _es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
 _es_port=80
 _es_baseline=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -31,6 +31,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+  cerberus_url: "$CERBERUS_URL" 
   workload:
     name: uperf
     args:
@@ -62,6 +63,10 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
   oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
@@ -76,7 +81,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o json | jq -r .items[].status.uuid)
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 baseline_uperf_uuid=${_baseline_hostnet_uuid}
 
 if [[ ${COMPARE} == "true" ]]; then

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -51,6 +51,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+  cerberus_url: "$CERBERUS_URL" 
   workload:
     name: uperf
     args:
@@ -85,6 +86,10 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
   oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
@@ -99,7 +104,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o json | jq -r .items[].status.uuid)
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 baseline_uperf_uuid=${_baseline_multus_uuid}
 
 if [[ ${COMPARE} == "true" ]]; then

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -42,6 +42,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+  cerberus_url: "$CERBERUS_URL" 
   workload:
     name: uperf
     args:
@@ -73,6 +74,10 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
   oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
@@ -87,7 +92,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o json | jq -r .items[].status.uuid)
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 if [ "${pairs}" == "1" ] ; then
   baseline_uperf_uuid=${_baseline_pod_1p_uuid}
 elif [ "${pairs}" == "2" ] ; then

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -42,6 +42,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+  cerberus_url: "$CERBERUS_URL" 
   workload:
     name: uperf
     args:
@@ -73,6 +74,10 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
   oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
@@ -87,7 +92,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o json | jq -r .items[].status.uuid)
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 if [ "${pairs}" == "1" ] ; then
   baseline_uperf_uuid=${_baseline_svc_1p_uuid}
 elif [ "${pairs}" == "2" ] ; then


### PR DESCRIPTION
This commit will give us the ability to check the health of the cluster before starting uperf and also while it is running. If the cluster is unhealthy the workload will fail and exit out
Fixes https://github.com/cloud-bulldozer/plow/issues/34