### PR TITLE
have the gsheet key in a central location and rectified edge cases

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -103,9 +103,13 @@ Accepeted deviation in percentage for latency when compared to a baseline run
 Default: ``     
 URL to check the health of the cluster using Cerberus (https://github.com/openshift-scale/cerberus).
 
+### GSHEET_KEY_LOCATION
+Default: *Commented out*      
+The location where you placed your Google Service Account Key. ex: `$HOME/.secrets/gsheet_key.json`
+
 ### EMAIL_ID_FOR_RESULTS_SHEET
 Default: *Commented out*       
-For this you will have to place Google Service Account Key in /plow/workloads/network-perf dir.   
+For this you will have to place Google Service Account Key in the $GSHEET_KEY_LOCATION   
 It will push your local results CSV to Google Spreadsheets and send an email with the attachment
 
 ## Suggested configurations
@@ -133,6 +137,7 @@ export BASELINE_MULTUS_UUID=
 export THROUGHPUT_TOLERANCE=5
 export LATENCY_TOLERANCE=5
 export CERBERUS_URL=http://1.2.3.4:8080
+#export GSHEET_KEY_LOCATION=
 #export EMAIL_ID_FOR_RESULTS_SHEET=<your_email_id>  # Will only work if you have google service account key
 ```
 

--- a/workloads/network-perf/csv_gen.py
+++ b/workloads/network-perf/csv_gen.py
@@ -189,8 +189,8 @@ parser.add_argument(
 )
 params = parser.parse_args()
 generate_csv(params.yaml_files, f"{params.sheetname}.csv")
-if "EMAIL_ID_FOR_RESULTS_SHEET" in os.environ:
+if "EMAIL_ID_FOR_RESULTS_SHEET" and "GSHEET_KEY_LOCATION" in os.environ:
     push_to_gsheet(
-        f"{params.sheetname}.csv", "gsheet_key.json", os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
+        f"{params.sheetname}.csv", os.environ["GSHEET_KEY_LOCATION"], os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
     )
 

--- a/workloads/network-perf/run_network_compare.sh
+++ b/workloads/network-perf/run_network_compare.sh
@@ -2,11 +2,8 @@
 datasource="elasticsearch"
 tool="uperf"
 function="compare"
-_es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
-_es_port=80
-_es_baseline=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
-_es_baseline_port=80
-
+_es=${ES_SERVER:-search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com}
+_es_port=${ES_PORT:-80}
 
 if [[ ${ES_SERVER} ]] && [[ ${ES_PORT} ]] && [[ ${ES_USER} ]] && [[ ${ES_PASSWORD} ]]; then
   _es=${ES_USER}:${ES_PASSWORD}@${ES_SERVER}
@@ -15,6 +12,9 @@ elif [[ ${ES_SERVER} ]] && [[ ${ES_PORT} ]]; then
   _es=${ES_SERVER}
   _es_port=${ES_PORT}
 fi
+
+_es_baseline=${ES_SERVER_BASELINE:-$_es}
+_es_baseline_port=${ES_PORT_BASELINE:-$_es_port}
 
 if [[ ${ES_SERVER_BASELINE} ]] && [[ ${ES_PORT_BASELINE} ]] && [[ ${ES_USER_BASELINE} ]] && [[ ${ES_PASSWORD_BASELINE} ]]; then
   _es_baseline=${ES_USER_BASELINE}:${ES_PASSWORD_BASELINE}@${ES_SERVER_BASELINE}
@@ -42,7 +42,7 @@ if [[ $? -ne 0 ]] ; then
   exit 1
 fi
 set -x
-touchstone_compare $tool $datasource ripsaw -url $_es_baseline:$_es_baseline_port $_es:$_es_port -u $base_uuid $compare_uuid -o yaml | tee ../compare_output_${!#}p.yaml
+touchstone_compare $tool $datasource ripsaw -url $_es:$_es_port $_es_baseline:$_es_baseline_port -u $base_uuid $compare_uuid -o yaml | tee ../compare_output_${!#}p.yaml
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to run touchstone"
   exit 1


### PR DESCRIPTION
having the keys in central location helps when we are cloning the repo over the existing one ex: scale-ci-pipeline. Also we already have /root/.secrets dir for GCP install and it's service account key. so leveraging that and going forward this location would be good to store creds

rectified edge case
`touchstone_compare ... username:password@$_es:$_es_port     username:password@$_es:$_es_port ... `
instead of 
`touchstone_compare ... username:password@_es:_es_port         _es:_es_port   ... `
which resulted in auth error